### PR TITLE
adding riscv installation instructions for macOS with fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,62 @@ Various files for bringing up the Single-Chip Micro Mote V (SCμM-V)
 
 📖 **[SCuM-V Documentation (Nextra Site)](https://ucb-ee290c.github.io/scum-v-bringup/)** - Interactive documentation
 
-### Legacy Documentation
-- [SCuM-V23 PDF Version](https://github.com/ucb-ee290c/scum-v-bringup/raw/gh-pages/SCuM-V23.pdf)
-- [SCuM-V23 Web Version (Legacy)](https://ucb-ee290c.github.io/scum-v-bringup/docs/)
-
 ### Contributing to Documentation
-- **Nextra Documentation**: Edit files in `docs-nextra/` and submit pull requests
+- **Nextra Documentation**: Edit files in `docs/` and submit pull requests
 - **Legacy AsciiDoc**: See [Contributing to the specification document](docs/README.md)
+
+### Installing Node.js and npm
+
+npm is bundled with Node.js. Install Node.js for your OS, then verify with `node -v` and `npm -v`.
+
+- **Windows**:
+  - Download the LTS installer from the [official Node.js download page](https://nodejs.org/en/download/)
+  - Run the `.msi` and follow the prompts
+  - Verify: `node -v` and `npm -v`
+
+- **macOS**:
+  - Install Homebrew (if not installed):
+    ```bash
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    ```
+  - Install Node.js (includes npm):
+    ```bash
+    brew install node
+    ```
+  - Verify: `node -v` and `npm -v`
+
+- **Linux (Ubuntu/Debian)**:
+  - Update and install:
+    ```bash
+    sudo apt update
+    sudo apt install nodejs npm
+    ```
+  - Verify: `node -v` and `npm -v`
+
+- **More options**: See the official npm guide: [Downloading and installing Node.js and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
+
+#### How to contribute to the docs
+1. Fork the repo on GitHub: [ucb-ee290c/scum-v-bringup](https://github.com/ucb-ee290c/scum-v-bringup)
+2. Clone your fork:
+   ```bash
+   git clone https://github.com/<your-username>/scum-v-bringup.git
+   cd scum-v-bringup
+   ```
+3. Create a branch:
+   ```bash
+   git checkout -b docs/your-change
+   ```
+4. Edit files under `docs/`, preview locally (below), commit and push:
+   ```bash
+   git add .
+   git commit -m "docs: describe your change"
+   git push origin docs/your-change
+   ```
+5. Open a Pull Request to `ucb-ee290c/scum-v-bringup` with a clear description.
 
 ### Building Documentation Locally
 ```bash
-cd docs-nextra
+cd docs
 npm install
 npm run dev    # Development server at http://localhost:3000
 npm run build  # Production build

--- a/docs/pages/firmware-development.mdx
+++ b/docs/pages/firmware-development.mdx
@@ -56,11 +56,9 @@ cd ~/Downloads/riscv-gnu-toolchain/
 
 Run configuration. The prefix is where we want to install the toolchain. Here, we will be installing under the `riscv64-unknown-toolchain` directory. NOTE: MAKE SURE TO ADD `--with-languages="c,c++,fortran". `
 
-{% code overflow="wrap" %}
 ```bash
 ./configure --prefix=/home/tk/Documents/RISCV/riscv64-unknown-toolchain/ --with-multilib-generator="rv32i-ilp32--;rv32im-ilp32--;rv32iac-ilp32--;rv32imac-ilp32--;rv32imafc-ilp32f--;rv64imac-lp64--;rv64imafdc-lp64d--" --with-languages="c,c++,fortran"
 ```
-{% endcode %}
 
 
 Build the toolchain

--- a/docs/pages/firmware-development.mdx
+++ b/docs/pages/firmware-development.mdx
@@ -9,20 +9,21 @@ import { Callout, FileTree, Steps } from 'nextra/components'
 ### Windows Setup
 
 <Steps>
-### Install MSYS2
+
+#### Install MSYS2
 Download from [https://www.msys2.org/](https://www.msys2.org/) and follow installation instructions
 
-### Install RISC-V Toolchain
+#### Install RISC-V Toolchain
 Download xpack distribution: [RISC-V GCC xPack](https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/)
 Extract to desired location (e.g., `C:\riscv\`)
 
-### Configure MSYS2 Environment
+#### Configure MSYS2 Environment
 ```bash
 export PATH=/c/riscv/xpack-riscv-none-elf-gcc-13.2.0-2/bin:$PATH
 ```
 </Steps>
 
-### Linux/macOS Setup
+### Linux Setup
 
 Follow the comprehensive setup guide from the Baremetal-IDE documentation:
 
@@ -35,10 +36,13 @@ This guide covers:
 - Environment configuration
 
 
-# Setting up RISC-V Toolchain - Mac
+### Mac Setup
 Credit to: https://ucb-bar.gitbook.io/chipyard/quickstart/setting-up-risc-v-toolchain/setting-up-risc-v-toolchain-mac
 
-## 1. Install RISC-V Toolchain
+
+<Steps>
+
+#### Install dependencies with `brew`
 
 First, we need to install the following dependencies.
 
@@ -46,7 +50,7 @@ First, we need to install the following dependencies.
 brew install python3 gawk gnu-sed gmp mpfr libmpc isl zlib expat texinfo flock
 ```
 
-Clone the RISC-V GNU Toolchain repo.
+#### Clone the RISC-V GNU Toolchain repo.
 
 ```bash
 cd ~/Downloads
@@ -54,23 +58,28 @@ git clone https://github.com/riscv-collab/riscv-gnu-toolchain.git
 cd ~/Downloads/riscv-gnu-toolchain/
 ```
 
-Run configuration. The prefix is where we want to install the toolchain. Here, we will be installing under the `riscv64-unknown-toolchain` directory. NOTE: MAKE SURE TO ADD `--with-languages="c,c++,fortran". `
+#### Run configuration. 
+
+The prefix is where we want to install the toolchain. Here, we will be installing under the `riscv64-unknown-toolchain` directory. 
+
+<Callout type="warning">
+1. NOTE: MAKE SURE TO ADD `--with-languages="c,c++,fortran"`, this differs from the Chipyard documentation linked above (it is outdated).
+2. You will need to change `/home/tk/Documents/RISCV/riscv64-unknown-toolchain/` to your own preferred installation directory.
+</Callout>
 
 ```bash
 ./configure --prefix=/home/tk/Documents/RISCV/riscv64-unknown-toolchain/ --with-multilib-generator="rv32i-ilp32--;rv32im-ilp32--;rv32iac-ilp32--;rv32imac-ilp32--;rv32imafc-ilp32f--;rv64imac-lp64--;rv64imafdc-lp64d--" --with-languages="c,c++,fortran"
 ```
 
 
-Build the toolchain
+#### Build the toolchain
 
 ```bash
 make -j8
 ```
 
+</Steps>
 
-Reference
-
-[https://github.com/riscv/riscv-openocd/blob/riscv/README.macOS](https://github.com/riscv/riscv-openocd/blob/riscv/README.macOS)
 
 ## Firmware Architecture
 

--- a/docs/pages/firmware-development.mdx
+++ b/docs/pages/firmware-development.mdx
@@ -34,6 +34,46 @@ This guide covers:
 - Building from source
 - Environment configuration
 
+
+# Setting up RISC-V Toolchain - Mac
+Credit to: https://ucb-bar.gitbook.io/chipyard/quickstart/setting-up-risc-v-toolchain/setting-up-risc-v-toolchain-mac
+
+## 1. Install RISC-V Toolchain
+
+First, we need to install the following dependencies.
+
+```bash
+brew install python3 gawk gnu-sed gmp mpfr libmpc isl zlib expat texinfo flock
+```
+
+Clone the RISC-V GNU Toolchain repo.
+
+```bash
+cd ~/Downloads
+git clone https://github.com/riscv-collab/riscv-gnu-toolchain.git
+cd ~/Downloads/riscv-gnu-toolchain/
+```
+
+Run configuration. The prefix is where we want to install the toolchain. Here, we will be installing under the `riscv64-unknown-toolchain` directory. NOTE: MAKE SURE TO ADD `--with-languages="c,c++,fortran". `
+
+{% code overflow="wrap" %}
+```bash
+./configure --prefix=/home/tk/Documents/RISCV/riscv64-unknown-toolchain/ --with-multilib-generator="rv32i-ilp32--;rv32im-ilp32--;rv32iac-ilp32--;rv32imac-ilp32--;rv32imafc-ilp32f--;rv64imac-lp64--;rv64imafdc-lp64d--" --with-languages="c,c++,fortran"
+```
+{% endcode %}
+
+
+Build the toolchain
+
+```bash
+make -j8
+```
+
+
+Reference
+
+[https://github.com/riscv/riscv-openocd/blob/riscv/README.macOS](https://github.com/riscv/riscv-openocd/blob/riscv/README.macOS)
+
 ## Firmware Architecture
 
 ### Project Structure

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -47,6 +47,7 @@ This repository contains FPGA controllers, host software, firmware, and document
   </Cards.Card>
 </Cards>
 
+
 ## Technical Documentation
 
 ### Core Systems
@@ -134,3 +135,54 @@ This repository contains FPGA controllers, host software, firmware, and document
 <Callout type="info">
 This project is developed as part of UC Berkeley's EE194/EE290C Special Topics in Circuit Design course.
 </Callout>
+
+## How to contribute to the docs 
+
+### Install Node.js and npm
+
+npm comes with Node.js.
+
+- **Windows**: Download the LTS installer from the [official Node.js download page](https://nodejs.org/en/download/). After installing, check with `node -v` and `npm -v`.
+- **macOS**: Install via Homebrew:
+  ```bash
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  brew install node
+  ```
+  Verify with `node -v` and `npm -v`.
+- **Linux (Ubuntu/Debian)**:
+  ```bash
+  sudo apt update
+  sudo apt install nodejs npm
+  ```
+  Verify with `node -v` and `npm -v`.
+
+More options and details: [npm docs – Downloading and installing Node.js and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
+
+### Make changes
+
+1. Fork the repo on GitHub: [ucb-ee290c/scum-v-bringup](https://github.com/ucb-ee290c/scum-v-bringup)
+2. Clone your fork:
+   ```bash
+   git clone https://github.com/<your-username>/scum-v-bringup.git
+   cd scum-v-bringup
+   ```
+3. Create a branch:
+   ```bash
+   git checkout -b docs/your-change
+   ```
+4. Edit files under `docs/`, preview locally (below), commit and push:
+   ```bash
+   git add .
+   git commit -m "docs: describe your change"
+   git push origin docs/your-change
+   ```
+5. Open a Pull Request to `ucb-ee290c/scum-v-bringup` with a clear description.
+
+### Build and view documentation locally
+```bash
+cd docs
+npm install
+npm run dev    # Development server at http://localhost:3000
+npm run build  # Production build
+```
+


### PR DESCRIPTION
Adding `--with-languages="c,c++,fortran"` in the `./configure` command to install riscv on macOS instructions.